### PR TITLE
only pick the first 'available' ebs volume that matches the tag

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -17,7 +17,7 @@ define ebs::volume (
   $aws_region = inline_template("<%= @ec2_placement_availability_zone.gsub(/.$/,'') %>")
 
   exec { "EBS volume ${name}: obtaining the volume id":
-    command     => "aws ec2 describe-volumes --filters Name='tag:name',Values=${name} --query 'Volumes[*].{ID:VolumeId, State:State}' | grep 'ID' | cut -d':' -f 2 | tr -d ' \"' > ${volume_id_file}",
+    command     => "aws ec2 describe-volumes --filters Name='tag:name',Values=${name}  Name='status',Values='available' --query 'Volumes[*].{ID:VolumeId, State:State}' | grep 'ID' | cut -d':' -f 2 | tr -d ' \"' | head -n 1 > ${volume_id_file}",
     unless      => "test -s ${volume_id_file}",
     environment => "AWS_DEFAULT_REGION=${aws_region}"
   } ->


### PR DESCRIPTION
currently it breaks when there are multiple ebs volumes matching the tag and also we are generally only interested in the 'available' volumes.
