### PR TITLE
Replace hardcoded puppet_vardir location to use puppet_vardir fact

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -14,7 +14,7 @@ define ebs::volume (
   }
 
   $volume_id_file = "${puppet_vardir}/.ebs__${name}__volume_id"
-  $aws_region = inline_template("<%= @ec2_placement_availability_zone&.gsub(/.$/,'') %>")
+  $aws_region = $facts['ec2_metadata']['placement']['region']
 
   exec { "EBS volume ${name}: obtaining the volume id":
     command     => "aws ec2 describe-volumes --filters Name='tag:name',Values=${name} --query 'Volumes[*].{ID:VolumeId, State:State}' | grep 'ID' | cut -d':' -f 2 | tr -d ' \"' > ${volume_id_file}",

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -14,7 +14,7 @@ define ebs::volume (
   }
 
   $volume_id_file = "${puppet_vardir}/.ebs__${name}__volume_id"
-  $aws_region = inline_template("<%= @ec2_placement_availability_zone.gsub(/.$/,'') %>")
+  $aws_region = inline_template("<%= @ec2_placement_availability_zone&.gsub(/.$/,'') %>")
 
   exec { "EBS volume ${name}: obtaining the volume id":
     command     => "aws ec2 describe-volumes --filters Name='tag:name',Values=${name} --query 'Volumes[*].{ID:VolumeId, State:State}' | grep 'ID' | cut -d':' -f 2 | tr -d ' \"' > ${volume_id_file}",

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -24,7 +24,9 @@ define ebs::volume (
   } ->
 
   exec { "EBS volume ${name}: volume id sanity check":
-    command => "[ `wc -l ${volume_id_file} | awk '{print \$1}'` -eq 1 ]"
+    command => "[ `wc -l ${volume_id_file} | awk '{print \$1}'` -eq 1 ]",
+    refreshonly => true,
+    subscribe   => Exec["EBS volume ${name}: obtaining the volume id"],
   } ->
 
   exec { "EBS volume ${name}: attaching the volume":
@@ -37,7 +39,9 @@ define ebs::volume (
     command   => "lsblk -fn ${device_attached}",
     tries     => 6,
     try_sleep => 10,
-    logoutput => true
+    logoutput => true,
+    refreshonly => true,
+    subscribe   => Exec["EBS volume ${name}: attaching the volume"],
   } ->
 
   exec { "EBS volume ${name}: formatting the volume":

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -15,9 +15,10 @@ define ebs::volume (
 
   $volume_id_file = "${puppet_vardir}/.ebs__${name}__volume_id"
   $aws_region = $facts['ec2_metadata']['placement']['region']
+  $ec2_instance_id =  $facts['ec2_metadata']['instance-id']
 
   exec { "EBS volume ${name}: obtaining the volume id":
-    command     => "aws ec2 describe-volumes --filters Name='tag:name',Values=${name} --query 'Volumes[*].{ID:VolumeId, State:State}' | grep 'ID' | cut -d':' -f 2 | tr -d ' \"' > ${volume_id_file}",
+    command     => "aws ec2 describe-volumes --filters Name='tag:Name',Values=${name} --query 'Volumes[*].{ID:VolumeId, State:State}' | grep 'ID' | cut -d':' -f 2 | tr -d ' \",' > ${volume_id_file}",
     unless      => "test -s ${volume_id_file}",
     environment => "AWS_DEFAULT_REGION=${aws_region}"
   } ->

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -13,7 +13,7 @@ define ebs::volume (
     path => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin'
   }
 
-  $volume_id_file = "/var/lib/puppet/.ebs__${name}__volume_id"
+  $volume_id_file = "${puppet_vardir}/.ebs__${name}__volume_id"
   $aws_region = inline_template("<%= @ec2_placement_availability_zone.gsub(/.$/,'') %>")
 
   exec { "EBS volume ${name}: obtaining the volume id":

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -36,10 +36,10 @@ define ebs::volume (
   } ->
 
   exec { "EBS volume ${name}: waiting for the volume to be attached":
-    command   => "lsblk -fn ${device_attached}",
-    tries     => 6,
-    try_sleep => 10,
-    logoutput => true,
+    command     => "lsblk -fn ${device_attached}",
+    tries       => 6,
+    try_sleep   => 10,
+    logoutput   => true,
     refreshonly => true,
     subscribe   => Exec["EBS volume ${name}: attaching the volume"],
   } ->

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ignis-ebs",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Iaroslav Tarasenko",
   "summary": "Attach and partition EBS volumes",
   "license": "MIT",


### PR DESCRIPTION
This change is to make the module compatible with newer versions of Puppet (Puppet 7) i.e. the /var/lib/puppet no longer exists/is created in newer versions of puppet.